### PR TITLE
Typo in introduction of the demo notebook: svg2pdf => pdf2svg

### DIFF
--- a/Quickstart.ipynb
+++ b/Quickstart.ipynb
@@ -189,7 +189,7 @@
     "    \n",
     "- Writes the cell as a `.tex` file; \n",
     "- Runs `pdflatex` on the source;\n",
-    "- Runs `svg2pdf` on the generated pdf;\n",
+    "- Runs `pdf2svg` on the generated pdf;\n",
     "- Removes the intermediary artifacts.\n",
     "\n",
     "By default, the filenames are the `md5` hash of the source. The extension uses the hash to see if regeneration is necessessary. If it's not, it just loads the SVG file."


### PR DESCRIPTION
Typo in introduction of the demo notebook: svg2pdf => pdf2svg