### PR TITLE
Add optional DPI spec for svg2png raster. E.g. " --rasterize --dpi=300 "

### DIFF
--- a/itikz/__init__.py
+++ b/itikz/__init__.py
@@ -97,6 +97,10 @@ def parse_args(line):
                         action='store_true', default=False,
                         help="Rasterize the svg with cairosvg")
 
+    parser.add_argument('--dpi', dest='dpi',
+                        default='',
+                        help="DPI passed to cairosvg.svg2png when 'rasterize' is used")
+
     parser.add_argument('--full-error', dest='full_err',
                         action='store_true', default=False,
                         help="Emit the full error message")
@@ -236,7 +240,9 @@ class TikZMagics(Magics):
                 print("$ pip install cairosvg", file=sys.stderr)
                 return
 
-            png_bytes = cairosvg.svg2png(bytestring=svg.data.encode())
+            raster_args = {"dpi": float(args.dpi)} if args.dpi else {}
+
+            png_bytes = cairosvg.svg2png(bytestring=svg.data.encode(), **raster_args)
 
             return Image(data=png_bytes)
 

--- a/tests/test_itikz.py
+++ b/tests/test_itikz.py
@@ -240,6 +240,26 @@ def test_rasterize_bad_input(itikz_magic):
     assert res is None
 
 
+def test_rasterize_and_dpi_good_input(itikz_magic):
+    pic = r"\node[draw] at (0,0) {Hello World};"
+    src = "\\begin{tikzpicture}\n" + pic + "\n\\end{tikzpicture}\n"
+    cmd = "--implicit-standalone --tex-packages=tikz --temp-dir --rasterize --dpi=200"
+    res = itikz_magic.itikz(cmd, src)
+    assert isinstance(res, Image)
+
+
+def test_rasterize_and_dpi_bad_input(itikz_magic):
+    cmd = "--temp-dir --rasterize --dpi=200"
+    res = itikz_magic.itikz(cmd, BAD_TIKZ)
+    assert res is None
+
+
+def test_dpi_no_rasterize_implicit_pic(itikz_magic):
+    src = r"\node[draw] at (0,0) {Hello World};"
+    res = itikz_magic.itikz("--implicit-pic --dpi=200 --temp-dir", src)
+    assert isinstance(res, SVG)
+
+
 def test_rasterize_no_cairo_svg(itikz_magic, monkeypatch, capsys):
     monkeypatch.setattr(itikz, 'CAIROSVG_ENABLED', False)
 


### PR DESCRIPTION
Legacy behavior does not change if DPI argument is excluded. DPI argument ignored if Rasterize argument excluded.